### PR TITLE
ベンチマーク実行時のログ移動で移動先のディレクトリが無く失敗していたため修正した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ restart:
 .PHONY: mv-logs
 mv-logs:
 	$(eval when := $(shell date "+%s"))
-	mkdir -p ~/logs/$(when)
+	mkdir -p ~/logs/nginx/$(when)
+	mkdir -p ~/logs/mysql/$(when)
 	sudo test -f $(NGINX_LOG) && \
 		sudo mv -f $(NGINX_LOG) ~/logs/nginx/$(when)/ || echo ""
 	sudo test -f $(DB_SLOW_LOG) && \


### PR DESCRIPTION
以下エラーを修正した

isucon@ip-192-168-0-11:~/isucon14$ make bench
SERVER_ID=s1
mkdir -p ~/logs/1733627671
sudo test -f /var/log/nginx/access.log && \
	sudo mv -f /var/log/nginx/access.log ~/logs/nginx/1733627671/ || echo ""
mv: cannot move '/var/log/nginx/access.log' to '/home/isucon/logs/nginx/1733627671/': No such file or directory

sudo test -f /var/log/mysql/mysql-slow.log && \
	sudo mv -f /var/log/mysql/mysql-slow.log ~/logs/mysql/1733627671/ || echo ""
mv: cannot move '/var/log/mysql/mysql-slow.log' to '/home/isucon/logs/mysql/1733627671/': No such file or directory