### PR TITLE
ridesテーブルのスロークエリ解消

### DIFF
--- a/webapp/sql/1-schema.sql
+++ b/webapp/sql/1-schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE rides
   PRIMARY KEY (id)
 )
   COMMENT = 'ライド情報テーブル';
+CREATE INDEX rides_chair_id_updated_at ON rides (chair_id, updated_at);
 
 DROP TABLE IF EXISTS ride_statuses;
 CREATE TABLE ride_statuses


### PR DESCRIPTION
```
# Query 4: 302.16 QPS, 0.78x concurrency, ID 0xD8DAD8AC6EDE2238F17AC39B0009258F at byte 7227201
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-12-08T03:44:48 to 2024-12-08T03:45:52
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          9   19338
# Exec time     10     50s   481us    20ms     3ms     7ms     2ms     2ms
# Lock time      5    22ms       0     2ms     1us     1us    12us     1us
# Rows sent      7  14.22k       0       1    0.75    0.99    0.43    0.99
# Rows examine  25  14.30M     750     799  775.34  793.42   16.56  755.64
# Query size     6   1.81M      98      98      98      98       0      98
# String:
# Databases    isuride
# Hosts        ip-192-168-0-11.ap-northeast-1.compute.inter...
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  #####################
#   1ms  ################################################################
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuride` LIKE 'rides'\G
#    SHOW CREATE TABLE `isuride`.`rides`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM rides WHERE chair_id = '01JEJ5X9XP7Z717DGQDVZX8T96' ORDER BY updated_at DESC LIMIT 1\G
```