### PR TITLE
chairseテーブルのaccess_tokenカラムにindexを貼った

### DIFF
--- a/webapp/sql/1-schema.sql
+++ b/webapp/sql/1-schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE chairs
   PRIMARY KEY (id)
 )
   COMMENT = '椅子情報テーブル';
+CREATE INDEX chairs_access_token ON chairs (access_token);
 
 DROP TABLE IF EXISTS chair_locations;
 CREATE TABLE chair_locations


### PR DESCRIPTION
```
# Query 2: 555.08 QPS, 0.77x concurrency, ID 0x49D4717E21912CD8B13961B8248A27CF at byte 3547057
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-12-08T06:25:52 to 2024-12-08T06:26:57
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          8   36080
# Exec time     16     50s   384us    39ms     1ms     4ms     1ms   761us
# Lock time      6    59ms       0     2ms     1us     1us    18us     1us
# Rows sent     10  35.23k       1       1       1       1       0       1
# Rows examine  42  18.12M     520     536  526.53  511.45    0.00  511.45
# Query size    11   3.72M     108     108     108     108       0     108
# String:
# Databases    isuride
# Hosts        ip-192-168-0-11.ap-northeast-1.compute.inter...
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  #######################################
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuride` LIKE 'chairs'\G
#    SHOW CREATE TABLE `isuride`.`chairs`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM chairs WHERE access_token = '3b1dc750583508c29485fbd55e99d86f32536b19e1b11c47dc025de19e4d8af2'\G
```